### PR TITLE
js processing errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,9 @@ var extension = 'html';
 /***** Functions for tasks *****/
 function js() {
 	return gulp.src(js_files)
+			.pipe(plumber({
+				errorHandler: onError
+			}))
 			.pipe(concat('dist'))
 			.pipe(rename('concat.min.js'))
 			.pipe(uglify())


### PR DESCRIPTION
Three lines added to make the error handling of JS. This causes the script to continue running and show where the error was (same as LESS files).
