### PR TITLE
removed tiny-lr, updated gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,9 +8,7 @@ var gulp       = require('gulp'),
 	minifyCSS  = require('gulp-minify-css'),
 	less       = require('gulp-less'),
 	path       = require('path'),
-	lr         = require('tiny-lr'),
-	livereload = require('gulp-livereload'),
-	server     = lr();
+	livereload = require('gulp-livereload');
 
 // Handle less error
 var onError = function (err) {
@@ -39,7 +37,7 @@ function js() {
 			.pipe(rename('concat.min.js'))
 			.pipe(uglify())
 			.pipe(gulp.dest(dist_path))
-			.pipe(livereload(server));
+			.pipe(livereload());
 }
 
 function css() {
@@ -48,7 +46,7 @@ function css() {
 			.pipe(rename('all.min.css'))
 			.pipe(minifyCSS({keepBreaks:true}))
 			.pipe(gulp.dest(dist_path))
-			.pipe(livereload(server));
+			.pipe(livereload());
 }
 
 function lessTask(err) {
@@ -58,12 +56,12 @@ function lessTask(err) {
 			}))
 			.pipe(less({ paths: [ path.join(__dirname, 'less', 'includes') ] }))
 			.pipe(gulp.dest(css_path))
-			.pipe(livereload(server));
+			.pipe(livereload());
 }
 
 function reloadBrowser() {
 	return gulp.src('*.' + extension)
-			.pipe(livereload(server));
+			.pipe(livereload());
 }
 
 // The 'js' task
@@ -88,26 +86,25 @@ gulp.task('reload-browser', function() {
 
 // The 'default' task.
 gulp.task('default', function() {
-	server.listen(35729, function (err) {
+	livereload.listen()
 
-		gulp.watch(less_file, function() {
-			if (err) return console.log(err);
-			return lessTask();
-		});
+	gulp.watch(less_file, function() {
+		// if (err) return console.log(err);
+		return lessTask();
+	});
 
-		gulp.watch(css_files, function() {
-			console.log('CSS task completed!');
-			return css();
-		});
+	gulp.watch(css_files, function() {
+		console.log('CSS task completed!');
+		return css();
+	});
 
-		gulp.watch(js_files, function() {
-			console.log('JS task completed!');
-			return js();
-		});
+	gulp.watch(js_files, function() {
+		console.log('JS task completed!');
+		return js();
+	});
 
-		gulp.watch('*.' + extension, function(){
-			console.log('Browse reloaded!');
-			return reloadBrowser();
-		});
+	gulp.watch('*.' + extension, function(){
+		console.log('Browse reloaded!');
+		return reloadBrowser();
 	});
 });

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "gulp-concat": ">=2.1.7",
     "gulp-livereload": ">=0.2.0",
     "gulp-minify-css": ">=0.2.0",
-    "tiny-lr": "0.0.5",
     "gulp-uglify": ">=0.2.0",
     "gulp-util": ">=2.2.13",
     "gulp-less": ">=1.2.0",


### PR DESCRIPTION
Removed superflous `tiny-lr` instance to avoid [port conflicts](https://github.com/vohof/gulp-livereload/issues/33). Updated gulpfile.js
